### PR TITLE
Remove unsupported .editorconfig MSBuild config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,5 +9,4 @@ tab_width = 4
 indent_style = space
 max_line_length = off
 
-dotnet_diagnostic.MSB3270.severity = silent
 dotnet_diagnostic.UNT0006.severity = silent


### PR DESCRIPTION
### Context

MSBuild is not suporting `.editorconfig` configurations. Such are currently ignored with no effect.
In the future MSBuild might use `.editorconfig` for configuring new types of checks. And to prevent the confusion, it might flag attempts to use it for traditional MSBxxxx codes. So the line being removed might lead to a warning in the future.